### PR TITLE
fix getTokens

### DIFF
--- a/src/home-connect-auth.html
+++ b/src/home-connect-auth.html
@@ -19,10 +19,17 @@
         button: {
             onclick: function() {
                 let currentUri = window.location;
+                let port;
+                if (currentUri.protocol === 'https' && currentUri.port && currentUri.port !== 443) {
+                    port = currentUri.port;
+                } else if (currentUri.protocol === 'http' && currentUri.port && currentUri.port !== 80) {
+                    port = currentUri.port;
+                }
+
                 $.getJSON('oauth2/' + this.id + '/auth/url', {
                     protocol: currentUri.protocol,
                     hostname: currentUri.hostname,
-                    port: currentUri.port || 80
+                    port: port
                 }, function(response) {
                     window.open(response.url);
                 });

--- a/src/home-connect-auth.js
+++ b/src/home-connect-auth.js
@@ -50,9 +50,12 @@ module.exports = function (RED) {
                 url: tokenHost + auth.tokenPath,
                 body: 'client_id=' + n.client_id + 
                     '&client_secret=' + n.client_secret + 
-                    '&grant_type=authorization_code&code=' + authCode
+                    '&grant_type=authorization_code&code=' + authCode +
+                    '&redirect_uri=' + node.context().get('callback_url')
             }, (error, response, body) => {
+
                 if (error || response.statusCode != 200) {
+                    n.status({ fill: 'red', shape:'dot', text: 'getTokens failed' });
                     return;
                 }
 
@@ -137,7 +140,7 @@ module.exports = function (RED) {
     });
 
     RED.httpAdmin.get('/oauth2/:id/auth/url', (req, res) => {
-        if (!req.query.protocol || !req.query.hostname || !req.query.port) {
+        if (!req.query.protocol || !req.query.hostname) {
             res.sendStatus(400);
             return;
         }

--- a/src/home-connect-request.js
+++ b/src/home-connect-request.js
@@ -39,8 +39,12 @@ module.exports = function (RED) {
                     settingkey: node.settingkey
                 })
                 .then(response => {
+                    let res = response.data;
+                    try {
+                        res = JSON.parse(res);
+                    } catch (error) {}
                     node.send({
-                        payload: response.data
+                        payload: res
                     });
                 })
                 .catch(error => {


### PR DESCRIPTION
my node-red instance is running behind a rev proxy that uses https, so I had to change the way the port is supplied in the getTokens function (was set to 80 which obviously failed). Also the API gave me an `incorrect redirect_uri parameter` when calling `/security/oauth/token` - so I added the redirect_uri here.